### PR TITLE
sc-2639 add corpus manager and vocab stats

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4==4.10.0
+gensim==4.1.1
+pytest==6.2.5

--- a/src/analyzer/vocab.py
+++ b/src/analyzer/vocab.py
@@ -1,0 +1,50 @@
+from src.corpus import OnlineTextCorpus
+
+from collections import Counter
+from gensim.corpora import Dictionary
+
+class VocabAnalyzer():
+    """
+    VocabAnalyzer computes vocab statistics given a gensim Dictionary.
+    """
+
+    def __init__(self, dictionary):
+        if not isinstance(dictionary, Dictionary):
+            raise ValueError("corpus must be a gensim Dictionary.")
+        self.dictionary = dictionary
+
+    def corpus_statistics(self):
+        """
+        Compute overall vocab statistics for the corpus and return the results.
+        """
+        stats = {}
+        stats["num_docs"] = self.dictionary.num_docs
+        stats["num_words"] = self.dictionary.num_pos
+        stats["unique_words"] = len(self.dictionary.cfs)
+        if self.dictionary.num_docs > 0:
+            stats["words_per_doc"] = self.dictionary.num_pos / self.dictionary.num_docs
+        else:
+            stats["words_per_doc"] = 0
+
+        rare_tokens = []
+        word_freq = Counter()
+        for token, id in self.dictionary.token2id.items():
+            if self.dictionary.cfs[id] == 1:
+                rare_tokens.append(token)
+            word_freq[token] = self.dictionary.cfs[id]
+
+        stats["most_common"] = word_freq.most_common(10)
+        stats["rare_words"] = rare_tokens
+        return stats
+
+    def word_statistics(self, word):
+        """
+        Compute vocab statistics for the given word.
+        """
+        if word not in self.dictionary.token2id:
+            return None
+        
+        stats = {}
+        stats["corpus_count"] = self.dictionary.cfs[self.dictionary.token2id[word]]
+        stats["doc_count"] = self.dictionary.dfs[self.dictionary.token2id[word]]
+        return stats

--- a/src/corpus.py
+++ b/src/corpus.py
@@ -1,0 +1,84 @@
+import os
+import shutil
+from gensim.corpora import Dictionary
+
+CORPUS_DIR = "corpus"
+DICT_NAME = "dict"
+
+class OnlineTextCorpus():
+    """
+    OnlineTextCorpus is a wrapper around gensim corpus data structures which is
+    expected to be updated on an event-driven basis (e.g., when new data is received).
+    The corpus is frequently checkpointed to disk to allow for data recovery.
+    TODO: Add a dense matrix format to support NLP transformations.
+    """
+    def __init__(self, dir, num_checkpoints=5):
+        if num_checkpoints < 1:
+            raise ValueError("num_checkpoints must be at least 1.")
+        self.dir = dir
+        self.num_checkpoints = num_checkpoints
+        self.dictionary = None
+        self.version = 0
+
+    def _corpus_path(self):
+        return os.path.join(self.dir, CORPUS_DIR + "_" + str(self.version))
+
+    def _dict_path(self):
+        return os.path.join(self._corpus_path(), DICT_NAME)
+
+    def get_dictionary(self):
+        """
+        Return the current dictionary, loading the most recent version from disk if
+        necessary.
+        """
+        if self.dictionary is None:
+            self.load()
+        return self.dictionary
+
+    def save(self):
+        """
+        Save the current corpus to disk.
+        """
+        if self.version > 0:
+            os.makedirs(self._corpus_path(), exist_ok=True)
+            self.dictionary.save(self._dict_path())
+            for f in os.listdir(self.dir):
+                # Remove older corpus versions.
+                if os.path.isdir(os.path.join(self.dir, f)) and f.startswith(CORPUS_DIR + "_"):
+                    version = int(f.split("_")[1])
+                    if version <= self.version - self.num_checkpoints:
+                        shutil.rmtree(os.path.join(self.dir, f))
+        else:
+            raise ValueError("Cannot save an empty corpus.")
+
+    def load(self):
+        """
+        Load the latest version of the corpus from disk.
+        """
+        if self.version > 0:
+            self.dictionary = Dictionary.load(self._dict_path())
+        else:
+            # Search for the latest version of the corpus.
+            latest_version = 0
+            for f in os.listdir(self.dir):
+                if f.startswith(CORPUS_DIR + "_"):
+                    version = int(f.split("_")[1])
+                    if version > latest_version:
+                        latest_version = version
+            if latest_version > 0:
+                self.version = latest_version
+                self.dictionary = Dictionary.load(self._dict_path())
+            else:
+                self.dictionary = Dictionary()
+                self.version = 0
+
+    def add_documents(self, documents):
+        """
+        Add a list of documents to the corpus, incrementing the version number and
+        checkpointing the results.
+        """
+        if self.dictionary is None:
+            self.load()
+        self.dictionary.add_documents(documents)
+        self.version += 1
+        self.save()

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,0 +1,110 @@
+from src.corpus import OnlineTextCorpus
+
+import os
+import pytest
+from gensim.corpora import Dictionary
+
+class TestOnlineTextCorpus():
+    """
+    Tests for the OnlineTextCorpus class.
+    """
+
+    @pytest.mark.parametrize(
+        "num_checkpoints",
+        [-1, 0]
+    )
+    def test_invalid_init(self, tmpdir, num_checkpoints):
+        """
+        Test that the class raises an exception when initialized with invalid
+        parameters.
+        """
+        with pytest.raises(ValueError):
+            corpus = OnlineTextCorpus(tmpdir, num_checkpoints=num_checkpoints)
+
+    def test_save_invalid(self, tmpdir):
+        """
+        Test that save() raises an exception when the corpus is empty.
+        """
+        corpus = OnlineTextCorpus(tmpdir)
+        corpus.dictionary = Dictionary()
+        with pytest.raises(ValueError):
+            corpus.save()
+
+    @pytest.mark.parametrize(
+        "num_checkpoints",
+        [1, 2, 5]
+    )
+    def test_save(self, tmpdir, num_checkpoints):
+        """
+        Test that save() saves the corpus to disk.
+        """
+        corpus = OnlineTextCorpus(tmpdir, num_checkpoints=num_checkpoints)
+        corpus.version = 1
+        corpus.dictionary = Dictionary([["hello", "world"]])
+        corpus.save()
+        corpus_path = os.path.join(tmpdir, "corpus_1")
+        assert os.path.isdir(corpus_path)
+        dict_path = os.path.join(corpus_path, "dict")
+        assert os.path.isfile(dict_path)
+
+        # Save a few more times to trigger version cleanup.
+        for i in range(num_checkpoints):
+            corpus.version += 1
+            corpus.save()
+        
+        # Check that the older versions of the corpus have been removed.
+        dirs = os.listdir(tmpdir)
+        assert len(dirs) == num_checkpoints
+        for d in dirs:
+            assert d.startswith("corpus_")
+            assert int(d.split("_")[1]) <= corpus.version
+            assert os.path.isfile(os.path.join(tmpdir, d, "dict"))
+
+    @pytest.mark.parametrize(
+        "num_checkpoints",
+        [1, 2, 5]
+    )
+    def test_load(self, tmpdir, num_checkpoints):
+        """
+        Test that load() loads the most recent version of the corpus from disk.
+        """
+        dictionary = Dictionary()
+        for i in range(num_checkpoints):
+            version = str(i + 1)
+            corpus_path = os.path.join(tmpdir, "corpus_" + version)
+            os.mkdir(corpus_path)
+            dictionary.add_documents([[version]])
+            dictionary.save(os.path.join(corpus_path, "dict"))
+        
+        corpus = OnlineTextCorpus(tmpdir, num_checkpoints=num_checkpoints)
+
+        # When there is a known version, that version should be loaded from disk.
+        corpus.version = 1
+        corpus.load()
+        assert str(corpus.version) in corpus.dictionary.token2id
+
+        # When the version is unknown, the latest version is used.
+        corpus.version = 0
+        corpus.load()
+        assert corpus.version == num_checkpoints
+        assert str(num_checkpoints) in corpus.dictionary.token2id
+
+    @pytest.mark.parametrize(
+        "documents, expected_words",
+        [
+            ([[]], 2),
+            ([["hello", "world"]], 2),
+            ([["the", "quick", "brown", "fox"],
+              ["jumped", "over", "the", "lazy", "dog"]], 10),
+        ]
+    )
+    def test_add_documents(self, tmpdir, documents, expected_words):
+        """
+        Test that add_documents() adds documents to the corpus.
+        """
+        corpus = OnlineTextCorpus(tmpdir)
+        corpus.add_documents([["hello", "world"]])
+        corpus.add_documents(documents)
+        assert corpus.version == 2
+        assert corpus.dictionary.num_docs == len(documents) + 1
+        assert len(corpus.dictionary.token2id) == expected_words

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -1,0 +1,70 @@
+from src.analyzer.vocab import VocabAnalyzer
+
+import pytest
+from gensim.corpora import Dictionary
+
+class TestVocabAnalyzer():
+    """
+    Tests for the VocabAnalyzer class.
+    """
+
+    @pytest.mark.parametrize(
+        "documents, expected",
+        [
+            ([], {
+                "num_docs": 0,
+                "num_words": 0,
+                "unique_words": 0,
+                "words_per_doc": 0,
+                "most_common": [],
+                "rare_words": [],
+            }),
+            ([
+                ["the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog", "in", "forest"],
+                ["the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog", "in", "forest"],
+                ["quick", "brown", "fox", "jumps", "over", "lazy", "dog", "in", "forest"],
+                ["brown", "fox", "jumps", "over", "lazy", "dog", "in", "forest"],
+                ["fox", "jumps", "over", "lazy", "dog", "in", "forest"],
+                ["jumps", "over", "lazy", "dog", "in", "forest"],
+                ["over", "lazy", "dog", "in", "forest"],
+                ["lazy", "dog", "in", "forest"],
+                ["dog", "in", "forest"],
+                ["in", "forest"],
+                ["forest"],
+                ["rare", "words"],
+              ], {
+                "num_docs": 12,
+                "num_words": 67,
+                "unique_words": 12,
+                "words_per_doc": 67 / 12,
+                "most_common": [("forest", 11), ("in", 10), ("dog", 9), ("lazy", 8), ("over", 7), ("jumps", 6), ("fox", 5), ("brown", 4), ("quick", 3), ("the", 2)],
+                "rare_words": ["rare", "words"],
+            }),
+        ]
+    )
+    def test_corpus_statistics(self, documents, expected):
+        """
+        Test that corpus_statistics() returns the correct results.
+        """
+        vocab = VocabAnalyzer(Dictionary(documents))
+        assert vocab.corpus_statistics() == expected
+
+    @pytest.mark.parametrize(
+        "documents, word, expected",
+        [
+            ([], "the", None),
+            ([
+                ["the", "quick", "brown", "fox", "jumps", "over", "the"],
+                ["lazy", "dog"],
+             ], "the", {
+                "corpus_count": 2,
+                "doc_count": 1,
+            }),
+        ]
+    )
+    def test_word_statistics(self, documents, word, expected):
+        """
+        Test that word_statistics() returns the correct results.
+        """
+        vocab = VocabAnalyzer(Dictionary(documents))
+        assert vocab.word_statistics(word) == expected


### PR DESCRIPTION
There are two parts to this PR that ended up being pretty independent from each other. The first is the `OnlineTextCorpus`. For right now this is a wrapper around the `gensim.corpora.Dictionary` but we will also want to add a matrix representation for NLP. The idea is that it can receive new data in batches and append it to an existing corpus, which enables updating NLP models on an event-driven basis. The other thing it does is backup the corpus to disk as a form of versioning. This could enable us to "diff" against previous versions of the corpus which would be pretty interesting.

The second part is the `VocabAnalyzer` which just parses statistics out of a gensim Dictionary and returns a dictionary that we could deliver to the frontend.