### PR TITLE
TopicAnalyzer refactor

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4==4.10.0
 gensim==4.1.1
 pytest==6.2.5
-sklearn==0.24.2
+scikit-learn==0.24.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4==4.10.0
 gensim==4.1.1
 pytest==6.2.5
-sklearn==0.0
+sklearn==1.0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4==4.10.0
 gensim==4.1.1
 pytest==6.2.5
-sklearn==1.0.2
+sklearn==0.24.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4==4.10.0
 gensim==4.1.1
 pytest==6.2.5
+sklearn==0.0

--- a/src/analyzer/engines/engine.py
+++ b/src/analyzer/engines/engine.py
@@ -11,7 +11,7 @@ class ModelingEngine():
         """
         Fits a set of models on the provided corpus.
         """
-        raise NotImplementedError("fit() must be implemented by a subclass.")
+        return self
 
     def update(self, documents):
         """

--- a/src/analyzer/engines/engine.py
+++ b/src/analyzer/engines/engine.py
@@ -1,0 +1,26 @@
+class ModelingEngine():
+    """
+    ModelingEngine defines a common interface for performing text modeling across
+    different modeling APIs.
+    """
+
+    def __init__(self):
+        self.models = {}
+
+    def fit(self, model, dictionary, corpus):
+        """
+        Fits a set of models on the provided corpus.
+        """
+        raise NotImplementedError("fit() must be implemented by a subclass.")
+
+    def update(self, documents):
+        """
+        Updates the set of models with a batch or stream of new corpus documents.
+        """
+        raise NotImplementedError("update() must be implemented by a subclass.")
+
+    def topics(self):
+        """
+        Return the evaluation results and metrics for the set of current models.
+        """
+        raise NotImplementedError("results() must be implemented by a subclass.")

--- a/src/analyzer/engines/gensim.py
+++ b/src/analyzer/engines/gensim.py
@@ -1,0 +1,71 @@
+from src.analyzer.engines.engine import ModelingEngine
+
+from gensim.models.coherencemodel import CoherenceModel
+from gensim.models.ldamodel import LdaModel
+from gensim.models.tfidfmodel import TfidfModel
+from gensim.models import Nmf
+
+class GensimEngine(ModelingEngine):
+    """
+    GensimEngine implements the methods for fitting and evaluating gensim models on a
+    corpus.
+    """
+    def __init__(self, min_topics, max_topics):
+        self.min_topics = min_topics
+        self.max_topics = max_topics
+        self.models = {}
+        self.dictionary = None
+        self.type = ""
+        self.corpus = None
+
+    def fit(self, model, dictionary, corpus, **kwargs):
+        """
+        Fits a set of models on the provided corpus.
+        """
+        if model == "lda":
+            self._fit_models(LdaModel, dictionary, corpus, **kwargs)
+        elif model == "nmf":
+            tfidf = TfidfModel(dictionary=dictionary)
+            self._fit_models(Nmf, dictionary, tfidf[corpus], **kwargs)
+        else:
+            raise ValueError("model must be either lda or nmf.")
+        self.dictionary = dictionary
+        self.type = model
+        self.corpus = corpus
+
+    def _fit_models(self, model_class, dictionary, corpus, **kwargs):
+        """
+        Fits several models with different numbers of topics on the given corpus.
+        """
+        for num_topics in range(self.min_topics, self.max_topics + 1):
+            print("fitting {} model with {} topics".format(model_class.__name__, num_topics))
+            model = model_class(corpus=corpus, id2word=dictionary, num_topics=num_topics, **kwargs)
+            cm = CoherenceModel(model=model, corpus=corpus, dictionary=dictionary, coherence='u_mass')
+            results = {}
+            results['coherence'] = cm.get_coherence()
+            print("coherence: {}".format(results['coherence']))
+            self.models[num_topics] = {}
+            self.models[num_topics]['model'] = model
+            self.models[num_topics]['results'] = results
+
+    def update(self, documents):
+        """
+        Updates the set of models with a stream of new corpus documents.
+        """
+        bow = [self.dictionary.doc2bow(doc, allow_update=True) for doc in documents]
+        self.corpus.append(bow)
+        for _, m in self.models.items():
+            m['model'].update(bow)
+            cm = CoherenceModel(model=m['model'], corpus=self.corpus, dictionary=self.dictionary, coherence='u_mass')
+            m['results']['coherence'] = cm.get_coherence()
+
+    def topics(self):
+        """
+        Return the discovered topics and evaluation metrics for the set of current models.
+        """
+        topics = {}
+        for k, m in self.models.items():
+            topics[k] = {}
+            topics[k]['coherence'] = m['results']['coherence']
+            topics[k]['topics'] = m['model'].show_topics(num_topics=k)
+        return topics

--- a/src/analyzer/engines/gensim.py
+++ b/src/analyzer/engines/gensim.py
@@ -10,53 +10,54 @@ class GensimEngine(ModelingEngine):
     GensimEngine implements the methods for fitting and evaluating gensim models on a
     corpus.
     """
-    def __init__(self, min_topics, max_topics):
+    def __init__(self, engine="lda", dictionary=None, min_topics=5, max_topics=10, **kwargs):
+        if self.engine not in ["lda", "nmf"]:
+            raise ValueError("engine must be either 'lda' or 'nmf'.")
+        self.engine = engine
+        self.dictionary = dictionary
+        self.engine_opts = kwargs
         self.min_topics = min_topics
         self.max_topics = max_topics
-        self.models = {}
-        self.dictionary = None
-        self.type = ""
-        self.corpus = None
+        self.models_ = {}
+        self.corpus_ = None
 
-    def fit(self, model, dictionary, corpus, **kwargs):
+    def fit(self, corpus):
         """
         Fits a set of models on the provided corpus.
         """
-        if model == "lda":
-            self._fit_models(LdaModel, dictionary, corpus, **kwargs)
-        elif model == "nmf":
-            tfidf = TfidfModel(dictionary=dictionary)
-            self._fit_models(Nmf, dictionary, tfidf[corpus], **kwargs)
+        if self.engine == "lda":
+            self._fit_models(LdaModel, corpus, **self.engine_opts)
+        elif self.engine == "nmf":
+            tfidf = TfidfModel(dictionary=self.dictionary)
+            self._fit_models(Nmf, tfidf[corpus], **self.engine_opts)
         else:
-            raise ValueError("model must be either lda or nmf.")
-        self.dictionary = dictionary
-        self.type = model
-        self.corpus = corpus
+            raise ValueError("engine must be either lda or nmf.")
+        self.corpus_ = corpus
 
-    def _fit_models(self, model_class, dictionary, corpus, **kwargs):
+    def _fit_models(self, model_class, corpus, **kwargs):
         """
         Fits several models with different numbers of topics on the given corpus.
         """
         for num_topics in range(self.min_topics, self.max_topics + 1):
             print("fitting {} model with {} topics".format(model_class.__name__, num_topics))
-            model = model_class(corpus=corpus, id2word=dictionary, num_topics=num_topics, **kwargs)
-            cm = CoherenceModel(model=model, corpus=corpus, dictionary=dictionary, coherence='u_mass')
+            model = model_class(corpus=corpus, id2word=self.dictionary, num_topics=num_topics, **kwargs)
+            cm = CoherenceModel(model=model, corpus=corpus, dictionary=self.dictionary, coherence='u_mass')
             results = {}
             results['coherence'] = cm.get_coherence()
             print("coherence: {}".format(results['coherence']))
-            self.models[num_topics] = {}
-            self.models[num_topics]['model'] = model
-            self.models[num_topics]['results'] = results
+            self.models_[num_topics] = {}
+            self.models_[num_topics]['model'] = model
+            self.models_[num_topics]['results'] = results
 
     def update(self, documents):
         """
         Updates the set of models with a stream of new corpus documents.
         """
         bow = [self.dictionary.doc2bow(doc, allow_update=True) for doc in documents]
-        self.corpus.append(bow)
-        for _, m in self.models.items():
+        self.corpus_.append(bow)
+        for _, m in self.models_.items():
             m['model'].update(bow)
-            cm = CoherenceModel(model=m['model'], corpus=self.corpus, dictionary=self.dictionary, coherence='u_mass')
+            cm = CoherenceModel(model=m['model'], corpus=self.corpus_, dictionary=self.dictionary, coherence='u_mass')
             m['results']['coherence'] = cm.get_coherence()
 
     def topics(self):
@@ -64,7 +65,7 @@ class GensimEngine(ModelingEngine):
         Return the discovered topics and evaluation metrics for the set of current models.
         """
         topics = {}
-        for k, m in self.models.items():
+        for k, m in self.models_.items():
             topics[k] = {}
             topics[k]['coherence'] = m['results']['coherence']
             topics[k]['topics'] = m['model'].show_topics(num_topics=k)

--- a/src/analyzer/engines/sklearn.py
+++ b/src/analyzer/engines/sklearn.py
@@ -1,0 +1,82 @@
+from src.analyzer.engines.engine import ModelingEngine
+
+import pandas as pd
+
+from sklearn.model_selection import GridSearchCV
+from sklearn.decomposition import LatentDirichletAllocation
+from sklearn.decomposition import NMF
+
+class SklearnEngine(ModelingEngine):
+    """
+    GensimEngine implements the methods for fitting and evaluating gensim models on a
+    corpus.
+    """
+    def __init__(self, min_topics, max_topics):
+        self.min_topics = min_topics
+        self.max_topics = max_topics
+        self.grid = None
+        self.model = None
+        self.vectorizer = None
+
+    def fit(self, type, vectorizer, corpus, **kwargs):
+        """
+        Fits a set of models on the provided corpus.
+        """
+        if type == "lda":
+            self._fit_lda(corpus, **kwargs)
+        elif type == "nmf":
+            self._fit_nmf(corpus, **kwargs)
+        else:
+            raise ValueError("model must be either lda or nmf.")
+        self.corpus = corpus
+        self.vectorizer = vectorizer
+
+    def _fit_lda(self, corpus, **kwargs):
+        """
+        Fits a set of models on the provided corpus.
+        """
+        print("fitting lda models on topic range {} to {}".format(self.min_topics, self.max_topics))
+        grid_params = {'n_components': list(range(self.min_topics, self.max_topics + 1))}
+        model = LatentDirichletAllocation(learning_method="online", **kwargs)
+        self.grid = GridSearchCV(model, param_grid=grid_params)
+        self.grid.fit(corpus)
+        self.model = self.grid.best_estimator_
+        print("best model params: {}".format(self.grid.best_params_))
+        print("best model score: {}".format(self.grid.best_score_))
+        print("perplexity: {}".format(self.model.perplexity(corpus)))
+
+    def _fit_nmf(self, corpus, **kwargs):
+        """
+        Fits a set of models on the provided corpus.
+        """
+        print("fitting nmf models on topic range {} to {}".format(self.min_topics, self.max_topics))
+        min_error = float("inf")
+        for num_topics in range(self.min_topics, self.max_topics + 1):
+            model = NMF(n_components=num_topics, **kwargs)
+            model.fit(corpus)
+            print("num topics: {} error {}".format(num_topics, model.reconstruction_err_))
+            if model.reconstruction_err_ < min_error:
+                min_error = model.reconstruction_err_
+                self.model = model
+        print("best model params: {}".format(self.model.get_params()))
+        print("best model score: {}".format(self.model.reconstruction_err_))
+
+    def update(self, documents):
+        """
+        Updates the set of models with a stream of new corpus documents.
+        """
+        self.grid.fit(documents)
+        self.model = self.grid.best_estimator_
+
+    def topics(self):
+        """
+        Return the discovered topics and evaluation metrics for the set of current models.
+        """
+        topics = {}
+        topic_list = []
+        feature_names = self.vectorizer.get_feature_names()
+        for idx, topic in enumerate(self.model.components_):
+            top_features_idx = topic.argsort()[:-10:-1]
+            top_features = [(feature_names[i], topic[i]) for i in top_features_idx]
+            topics[idx] = top_features
+        return topics

--- a/src/analyzer/engines/sklearn.py
+++ b/src/analyzer/engines/sklearn.py
@@ -1,33 +1,40 @@
+from sklearn.base import BaseEstimator, TransformerMixin
 from src.analyzer.engines.engine import ModelingEngine
 
 from sklearn.model_selection import GridSearchCV
 from sklearn.decomposition import LatentDirichletAllocation
 from sklearn.decomposition import NMF
 
-class SklearnEngine(ModelingEngine):
+class SklearnEngine(ModelingEngine, BaseEstimator, TransformerMixin):
     """
-    GensimEngine implements the methods for fitting and evaluating gensim models on a
-    corpus.
+    SklearnEngine implements the methods for fitting and evaluating sklearn models on a
+    corpus. This class implements the fit(), transform(), and predict() methods in
+    order to support use in sklearn pipelines.
     """
-    def __init__(self, min_topics, max_topics):
+    def __init__(self, engine="lda", vectorizer=None, min_topics=5, max_topics=10, **kwargs):
+        if self.engine not in ["lda", "nmf"]:
+            raise ValueError("engine must be either 'lda' or 'nmf'")
+        self.engine = engine
+        # TODO: Can we make the vectorizer part of the pipeline so we don't have to
+        #       pass it in here?
+        self.vectorizer = vectorizer
+        self.engine_opts = kwargs
         self.min_topics = min_topics
         self.max_topics = max_topics
-        self.grid = None
-        self.model = None
-        self.vectorizer = None
 
-    def fit(self, type, vectorizer, corpus, **kwargs):
+    def fit(self, corpus):
         """
-        Fits a set of models on the provided corpus.
+        Fits a set of models on the provided corpus, this conforms to a fit() method in
+        the sklearn API.
         """
-        if type == "lda":
-            self._fit_lda(corpus, **kwargs)
-        elif type == "nmf":
-            self._fit_nmf(corpus, **kwargs)
+        if self.engine == "lda":
+            self._fit_lda(corpus, **self.engine_opts)
+        elif self.engine == "nmf":
+            self._fit_nmf(corpus, **self.engine_opts)
         else:
-            raise ValueError("model must be either lda or nmf.")
-        self.corpus = corpus
-        self.vectorizer = vectorizer
+            raise ValueError("engine must be either 'lda' or 'nmf'")
+        self.corpus_ = corpus
+        return self
 
     def _fit_lda(self, corpus, **kwargs):
         """
@@ -36,12 +43,12 @@ class SklearnEngine(ModelingEngine):
         print("fitting lda models on topic range {} to {}".format(self.min_topics, self.max_topics))
         grid_params = {'n_components': list(range(self.min_topics, self.max_topics + 1))}
         model = LatentDirichletAllocation(learning_method="online", **kwargs)
-        self.grid = GridSearchCV(model, param_grid=grid_params)
-        self.grid.fit(corpus)
-        self.model = self.grid.best_estimator_
-        print("best model params: {}".format(self.grid.best_params_))
-        print("best model score: {}".format(self.grid.best_score_))
-        print("perplexity: {}".format(self.model.perplexity(corpus)))
+        self.grid_ = GridSearchCV(model, param_grid=grid_params)
+        self.grid_.fit(corpus)
+        self.model_ = self.grid_.best_estimator_
+        print("best model params: {}".format(self.grid_.best_params_))
+        print("best model score: {}".format(self.grid_.best_score_))
+        print("perplexity: {}".format(self.model_.perplexity(corpus)))
 
     def _fit_nmf(self, corpus, **kwargs):
         """
@@ -55,25 +62,36 @@ class SklearnEngine(ModelingEngine):
             print("num topics: {} error {}".format(num_topics, model.reconstruction_err_))
             if model.reconstruction_err_ < min_error:
                 min_error = model.reconstruction_err_
-                self.model = model
-        print("best model params: {}".format(self.model.get_params()))
-        print("best model score: {}".format(self.model.reconstruction_err_))
+                self.model_ = model
+        print("best model params: {}".format(self.model_.get_params()))
+        print("best model score: {}".format(self.model_.reconstruction_err_))
+
+    def transform(self, documents):
+        """
+        Implementation of the standard transform() method of the sklearn API.
+        """
+        self.update(self, documents)
 
     def update(self, documents):
         """
         Updates the set of models with a stream of new corpus documents.
         """
-        self.grid.fit(documents)
-        self.model = self.grid.best_estimator_
+        self.grid_.fit(documents)
+        self.model_ = self.grid_.best_estimator_
+
+    def predict(self):
+        """
+        Implementation of the standard predict() method of the sklearn API.
+        """
+        return self.topics()
 
     def topics(self):
         """
         Return the discovered topics and evaluation metrics for the set of current models.
         """
         topics = {}
-        topic_list = []
         feature_names = self.vectorizer.get_feature_names()
-        for idx, topic in enumerate(self.model.components_):
+        for idx, topic in enumerate(self.model_.components_):
             top_features_idx = topic.argsort()[:-10:-1]
             top_features = [(feature_names[i], topic[i]) for i in top_features_idx]
             topics[idx] = top_features

--- a/src/analyzer/engines/sklearn.py
+++ b/src/analyzer/engines/sklearn.py
@@ -1,7 +1,5 @@
 from src.analyzer.engines.engine import ModelingEngine
 
-import pandas as pd
-
 from sklearn.model_selection import GridSearchCV
 from sklearn.decomposition import LatentDirichletAllocation
 from sklearn.decomposition import NMF

--- a/src/analyzer/topic.py
+++ b/src/analyzer/topic.py
@@ -1,61 +1,32 @@
-from gensim.models.coherencemodel import CoherenceModel
-from gensim.models.ldamodel import LdaModel
-from gensim.models.tfidfmodel import TfidfModel
-from gensim.models import Nmf
+from src.analyzer.engines.gensim import GensimEngine
+from src.analyzer.engines.sklearn import SklearnEngine
 
 class TopicAnalyzer():
     """
     TopicAnalyzer supports fitting various topic models on a gensim corpus.
     """
-    def __init__(self, min_topics=5, max_topics=10):
-        self.min_topics = min_topics
-        self.max_topics = max_topics
-        self.models = {}
+    def __init__(self, engine, min_topics=5, max_topics=10):
+        if engine == "gensim":
+            self.engine = GensimEngine(min_topics, max_topics)
+        elif engine == "sklearn":
+            self.engine = SklearnEngine(min_topics, max_topics)
+        else:
+            raise ValueError("engine must be either 'gensim' or 'sklearn'.")
 
-    def _fit_models(self, model_class, dictionary, corpus, **kwargs):
+    def model(self, type, dictionary, corpus, **kwargs):
         """
-        Fits several models of the given type on the given dictionary and corpus with the given set of parameters.
+        Fit topic models using the current engine.
         """
-        for num_topics in range(self.min_topics, self.max_topics + 1):
-            print("fitting {} model with {} topics".format(model_class.__name__, num_topics))
-            model = model_class(corpus=corpus, id2word=dictionary, num_topics=num_topics, **kwargs)
-            cm = CoherenceModel(model=model, corpus=corpus, dictionary=dictionary, coherence='u_mass')
-            results = {}
-            results['coherence'] = cm.get_coherence()
-            print("coherence: {}".format(results['coherence']))
-            self.models[num_topics] = {}
-            self.models[num_topics]['model'] = model
-            self.models[num_topics]['results'] = results
-
-    def fit_lda(self, dictionary, corpus, **kwargs):
-        """
-        Fits several LDA models on the given dictionary and corpus with the given set of
-        parameters.
-        """
-        self._fit_models(LdaModel, dictionary, corpus, **kwargs)
-        
-    def fit_nmf(self, dictionary, corpus, **kwargs):
-        """
-        Fits several NMF models on the given dictionary and corpus with the given set of
-        parameters.
-        """
-        tfidf = TfidfModel(dictionary=dictionary)
-        self._fit_models(Nmf, dictionary, tfidf[corpus], **kwargs)
+        self.engine.fit(type, dictionary, corpus, **kwargs)
 
     def update(self, documents):
         """
-        Updates the LDA model with a stream of new corpus documents.
+        Updates the models with new documents.
         """
-        for m in self.models:
-            model = m['model'].update(documents)
+        self.engine.update(documents)
 
     def topics(self):
         """
         Returns the topics for the models.
         """
-        topics = {}
-        for k, m in self.models.items():
-            topics[k] = {}
-            topics[k]['coherence'] = m['results']['coherence']
-            topics[k]['topics'] = m['model'].show_topics(num_topics=k)
-        return topics
+        return self.engine.topics()

--- a/src/analyzer/topic.py
+++ b/src/analyzer/topic.py
@@ -5,24 +5,34 @@ class TopicAnalyzer():
     """
     TopicAnalyzer supports fitting various topic models on a gensim corpus.
     """
-    def __init__(self, engine, min_topics=5, max_topics=10):
+    def __init__(self, engine="gensim", type="lda", dictionary=None, min_topics=5, max_topics=10, **kwargs):
         if engine == "gensim":
-            self.engine = GensimEngine(min_topics, max_topics)
+            if dictionary is None:
+                raise ValueError("must provide a Dictionary or HashDictionary for gensim engine")
+            self.engine = GensimEngine(engine=type, dictionary=dictionary, min_topics=min_topics, max_topics=max_topics, **kwargs)
         elif engine == "sklearn":
-            self.engine = SklearnEngine(min_topics, max_topics)
+            if dictionary is None:
+                raise ValueError("must provide a CountVectorizer or HashVectorizer for sklearn engine")
+            self.engine = SklearnEngine(engine=type, vectorizer=dictionary, min_topics=min_topics, max_topics=max_topics, **kwargs)
         else:
             raise ValueError("engine must be either 'gensim' or 'sklearn'.")
 
-    def model(self, type, dictionary, corpus, **kwargs):
+    def model(self, corpus=None):
         """
-        Fit topic models using the current engine.
+        Fit topic models using the current engine. Takes as input a list or iterable of
+        documents in bag-of-words format. This enables multiple engines to be used from
+        the same API.
         """
-        self.engine.fit(type, dictionary, corpus, **kwargs)
+        if corpus is None:
+            raise ValueError("must provide a list or iterable of BoW documents")
+        self.engine.fit(corpus)
 
-    def update(self, documents):
+    def update(self, documents=None):
         """
         Updates the models with new documents.
         """
+        if documents is None:
+            raise ValueError("must provide a list or iterable of BoW documents")
         self.engine.update(documents)
 
     def topics(self):


### PR DESCRIPTION
This refactors the TopicAnalyzer to support both sklearn and gensim topic modeling engines. I found this to be a useful abstraction when experimenting with both libraries and it's a first attempt at creating a standard API for topic modeling.

This PR also adds some fixes required for online topic modeling with gensim; this includes supporting the `HashDictionary` to allow for out-of-vocabulary model updates.