### PR TITLE
Add Kafka TopicReader

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4==4.10.0
 gensim==4.1.1
 pytest==6.2.5
+kafka-python==2.0.2

--- a/src/parser/html.py
+++ b/src/parser/html.py
@@ -16,13 +16,13 @@ class HTMLParser():
         """
         Return a generator that parses text content from the reader.
         """
-        try: 
-            for html in self.reader.read():
+        for html in self.reader.read():
+            try:
                 if html is None:
                     return
                 yield self._parse_text(html)
-        except Exception as e:
-            raise ValueError("Error retrieving file from reader: " + str(e))
+            except Exception as e:
+                print("Error parsing HTML: " + str(e))
 
     def _parse_text(self, html):
         """

--- a/src/parser/html.py
+++ b/src/parser/html.py
@@ -16,13 +16,14 @@ class HTMLParser():
         """
         Return a generator that parses text content from the reader.
         """
-        for html in self.reader.read():
-            try:
-                if html is None:
-                    return
-                yield self._parse_text(html)
-            except Exception as e:
-                print("Error parsing HTML: " + str(e))
+        try:
+            for html in self.reader.read():
+                try:
+                    yield self._parse_text(html)
+                except Exception as e:
+                    yield None
+        except Exception as e:
+            raise ValueError("Error reading from reader: " + str(e))
 
     def _parse_text(self, html):
         """
@@ -33,5 +34,5 @@ class HTMLParser():
         soup = BeautifulSoup(html, 'html.parser')
         text = ""
         for tag in soup.find_all(TAGS):
-            text += tag.text + " "
+            text += tag.text.strip() + " "
         return text.strip()

--- a/src/reader/kafka.py
+++ b/src/reader/kafka.py
@@ -1,0 +1,22 @@
+from src.reader.reader import Reader
+
+import json
+
+from kafka import KafkaConsumer
+
+class TopicReader(Reader):
+    """
+    TopicReader implements reading data from a Kafka topic into a stream.
+    """
+    def __init__(self, url, topic):
+        self.consumer = KafkaConsumer(topic, bootstrap_servers=url)
+
+    def read(self):
+        """
+        Read data from the Kafka topic into a stream.
+        """
+        for message in self.consumer:
+            try:
+                yield json.loads(message.value)
+            except Exception as e:
+                print("Error parsing topic: " + str(e))

--- a/src/reader/kafka.py
+++ b/src/reader/kafka.py
@@ -1,22 +1,67 @@
 from src.reader.reader import Reader
 
-import json
-
 from kafka import KafkaConsumer
+from kafka.structs import OffsetAndMetadata, TopicPartition
 
 class TopicReader(Reader):
     """
     TopicReader implements reading data from a Kafka topic into a stream.
+    Parameters:
+        url:
+            URL that points to a Kafka broker.
+        topic:
+            Kafka topic name to subscribe to.
+        resume_earliest:
+            If True, the consumer will start reading from the last committed offset
+            after a restart. If False, the consumer will start reading at the end of
+            the partition log. Default: True
+        auto_commit:
+            If True, the consumer will automatically commit read offsets every interval.
+            If False, the caller is responsible for committing offsets with the
+            commit() method. Default: True
+        group_id:
+            Kafka consumer group id, this is used internally by the consumer as an
+            identifier for automatic offset committing. Default: 'orca'
+        auto_commit_interval:
+            Time in milliseconds between automatic offset commits. Default: 5000
     """
-    def __init__(self, url, topic):
-        self.consumer = KafkaConsumer(topic, bootstrap_servers=url)
+    def __init__(self, url, topic, resume_earliest=True, auto_commit=True, group_id="orca", auto_commit_interval=5000):
+        if not isinstance(url, str) or url == "":
+            raise ValueError("Kafka broker URL is required.")
+        if not isinstance(topic, str) or topic == "":
+            raise ValueError("Kafka topic is required.")
+        self.topic = topic
+        if resume_earliest:
+            self.auto_offset_reset = "earliest"
+        else:
+            self.auto_offset_reset = "latest"
+        if auto_commit and group_id == "":
+            raise ValueError("Kafka group_id is required if auto_commit is True.")
+        self.message_ = None
+        try:
+            self.consumer = KafkaConsumer(
+                topic,
+                bootstrap_servers=url,
+                auto_offset_reset=self.auto_offset_reset,
+                enable_auto_commit=auto_commit,
+                group_id=group_id,
+                auto_commit_interval_ms=auto_commit_interval)
+        except Exception as e:
+            raise ValueError("Error configuring Kafka consumer: " + str(e))
 
     def read(self):
         """
         Read data from the Kafka topic into a stream.
         """
         for message in self.consumer:
-            try:
-                yield json.loads(message.value)
-            except Exception as e:
-                print("Error parsing topic: " + str(e))
+            self.message_ = message
+            yield message.value
+
+    def commit(self):
+        """
+        Commit the last read offset to Kafka. This enables the caller to control when
+        messages are considered 'committed' based on external logic.
+        """
+        if self.message_ is None:
+            raise ValueError("No message to commit.")
+        self.consumer.commit({TopicPartition(self.topic, self.message_.partition): OffsetAndMetadata(self.message_.offset + 1, None)})

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -41,7 +41,7 @@ class TestHTMLParser():
     @pytest.mark.parametrize(
         "html, expected",
         [
-            ([], [""]),
+            ([], []),
             (["<h1>Heading Text</h1>"], ["Heading Text"]),
             ([
                 "<h2>Heading</h2><p>Paragraph</p>",
@@ -49,6 +49,7 @@ class TestHTMLParser():
               ],
               ["Heading Paragraph", "Paragraph List"]),
             (["<h3>Heading</h3><a>Link</a><p>Paragraph</p>"], ["Heading Paragraph"]),
+            (["<h2>Heading Text<h2>", 42], ["Heading Text", None]),
         ]
     )
     def test_parse(self, html, expected):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -57,3 +57,4 @@ class TestHTMLParser():
         """
         parser = HTMLParser(StringReader(html))
         texts = list(parser.parse())
+        assert texts == expected


### PR DESCRIPTION
This adds a `TopicReader`, which is a `Reader` class that implements reading data from a Kafka topic. The `kafka-python` library abstracts a lot of the underlying complexity with the partitions and offsets but there is some configuration that can be passed through, mostly in regards to how the consumer reads are committed.